### PR TITLE
Add container as viable setup 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
       packages: write
       attestations: write
       id-token: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,7 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
     - name: Container Build & Push
+      id: push
       uses: docker/build-push-action@v6
       with:
         context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,19 +5,29 @@ on:
     tags:
       - '*'
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
-    - name: Setup php
+    - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.0'
+        php-version: '8.3'
         extensions: curl, mbstring, json
 
     - name: Build
@@ -33,3 +43,36 @@ jobs:
         tag: ${{ github.ref }}
         release_name: "Release ${{ github.ref_name }}"
         overwrite: true
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Container Registry Login
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.registry }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Container Build & Push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Container Registry Login
       uses: docker/login-action@v3
       with:
-        registry: ${{ env.registry }}
+        registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN <<-EOF
         apt-get install -y git
         apt-get clean
         rm -rf /var/lib/apt/lists/*
-    EOF
+EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM docker.io/library/php:8.3-cli
+WORKDIR /workdir
+ENTRYPOINT [ "/bb" ]
+ADD --chmod=755 bb.phar /bb
+RUN <<-EOF
+        apt-get update
+        apt-get install -y git
+        apt-get clean
+        rm -rf /var/lib/apt/lists/*
+    EOF

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ touch ~/.bitbucket-rest-cli-config.json
 
 Then, run the tool:
 ```shell
-docker run -it --mount type=bind,source="$HOME/.bitbucket-rest-cli-config.json",target=/root/.bitbucket-rest-cli-config.json --mount type=bind,source="$(pwd)",target=/workdir,readonly ghcr.io/bb-cli/bb-cli help
+docker run -it --rm --mount type=bind,source="$HOME/.bitbucket-rest-cli-config.json",target=/root/.bitbucket-rest-cli-config.json --mount type=bind,source="$(pwd)",target=/workdir,readonly ghcr.io/bb-cli/bb-cli help
 ```
 
 For ease, configure this as an alias in your chosen shell:
 ```shell
-alias bb='docker run -it --mount type=bind,source="$HOME/.bitbucket-rest-cli-config.json",target=/root/.bitbucket-rest-cli-config.json --mount type=bind,source="$(pwd)",target=/workdir,readonly ghcr.io/bb-cli/bb-cli'
+alias bb='docker run -it --rm --mount type=bind,source="$HOME/.bitbucket-rest-cli-config.json",target=/root/.bitbucket-rest-cli-config.json --mount type=bind,source="$(pwd)",target=/workdir,readonly ghcr.io/bb-cli/bb-cli'
 ```
 
 Then use `bb help` and `bb auth` as expected in the documentation.

--- a/README.md
+++ b/README.md
@@ -6,12 +6,31 @@ Use Bitbucket from command line. With this app you can see pull request, pipelin
 
 ## Installation
 
-__NOTE__: Before install this package, you should have **PHP >= 7** installed on your machine.
+__NOTE__: Before install this package, you should have **PHP >= 7** installed on your machine. For an alternative, use Docker instructions below.
 
 * Download standalone binary from [releases](https://github.com/bb-cli/bb-cli/releases)
-* Move downloaded file to path like `mv bb /usr/local/bin/bb`
+* Move downloaded file to path like `mv bb /usr/local/bin/bb` or `mv bb ~/.local/bin/bb`
 * For testing `bb help`
 * Let's move on to the [auth.](https://bb-cli.github.io/authentication)
+
+## Docker Setup
+As an alternative to having a PHP runtime installed locally, you can make use of a Docker container to run Bitbucket CLI.
+First, make sure to create `~/.bitbucket-rest-cli-config.json` beforehand:
+```shell
+touch ~/.bitbucket-rest-cli-config.json
+```
+
+Then, run the tool:
+```shell
+docker run -it --mount type=bind,source="$HOME/.bitbucket-rest-cli-config.json",target=/root/.bitbucket-rest-cli-config.json --mount type=bind,source="$(pwd)",target=/workdir,readonly ghcr.io/bb-cli/bb-cli help
+```
+
+For ease, configure this as an alias in your chosen shell:
+```shell
+alias bb='docker run -it --mount type=bind,source="$HOME/.bitbucket-rest-cli-config.json",target=/root/.bitbucket-rest-cli-config.json --mount type=bind,source="$(pwd)",target=/workdir,readonly ghcr.io/bb-cli/bb-cli'
+```
+
+Then use `bb help` and `bb auth` as expected in the documentation.
 
 ## Usage
 


### PR DESCRIPTION
Hello,

I don't like adding extra runtimes for CLI tools, but this is basically the only CLI-friendly Bitbucket API client I could find (thanks for this! 😁). I took it upon myself to setup a Docker container workflow that'd build and push to GitHub Container Registry at release time, so there's a lower-impact option for those who don't feel like contending with PHP directly.

Please let me know if this is desired at all - it works really well for me and the tool is small and light enough that I don't feel any extra overhead running it as a container. For what it's worth, you can see the end product here (though this will naturally publish as `ghcr.io/bb-cli/bb-cli`): https://github.com/mediowen/bb-cli/pkgs/container/bb-cli. To test, you can just use `alias bb='docker run -it --mount type=bind,source="$HOME/.bitbucket-rest-cli-config.json",target=/root/.bitbucket-rest-cli-config.json --mount type=bind,source="$(pwd)",target=/workdir --rm ghcr.io/mediowen/bb-cli:1.2.0`

As per your own recommendation, I'd suggest squashing this PR :) many commits are just bits of trial/error.

Thanks!