### PR TITLE
feat: add PR title and description support to create command

### DIFF
--- a/bin/bb
+++ b/bin/bb
@@ -59,13 +59,24 @@ $staticCommands = [
     ],
 ];
 
-// Check for --project argument and extract it
+// Check for --project, --title and --description arguments and extract them
 $projectUrl = null;
+$prTitle = null;
+$prDescription = null;
+$interactive = false;
 $filteredArgv = [];
 for ($i = 0; $i < count($argv); $i++) {
     if ($argv[$i] === '--project' && isset($argv[$i + 1])) {
         $projectUrl = $argv[$i + 1];
         $i++; // Skip the next argument (the URL)
+    } elseif ($argv[$i] === '--title' && isset($argv[$i + 1])) {
+        $prTitle = $argv[$i + 1];
+        $i++;
+    } elseif ($argv[$i] === '--description' && isset($argv[$i + 1])) {
+        $prDescription = $argv[$i + 1];
+        $i++;
+    } elseif ($argv[$i] === '-i' || $argv[$i] === '--interactive') {
+        $interactive = true;
     } else {
         $filteredArgv[] = $argv[$i];
     }
@@ -75,6 +86,17 @@ $argv = $filteredArgv;
 // Set global project URL for use in getRepoPath()
 if ($projectUrl) {
     $GLOBALS['bb_cli_project_url'] = $projectUrl;
+}
+
+// Set global PR title and description for use in Pr::create()
+if ($prTitle) {
+    $GLOBALS['bb_cli_pr_title'] = $prTitle;
+}
+if ($prDescription) {
+    $GLOBALS['bb_cli_pr_description'] = $prDescription;
+}
+if ($interactive) {
+    $GLOBALS['bb_cli_interactive'] = true;
 }
 
 $userBaseAction = $argv[1] ?? null;
@@ -91,7 +113,10 @@ if (is_null($userBaseAction) || in_array($userBaseAction, $staticCommands['help'
     o(array_keys($actions), 'green');
     o('', 'white');
     o('Global options:', 'green');
-    o('  --project <repo>  Work with repository (e.g., --project "owner/repo" or --project "https://bitbucket.org/owner/repo")', 'yellow');
+    o('  --project <repo>         Work with repository (e.g., --project "owner/repo" or --project "https://bitbucket.org/owner/repo")', 'yellow');
+    o('  -i, --interactive         Enable interactive mode (e.g., prompt for PR title and description)', 'yellow');
+    o('  --title <title>           Set PR title (used with pr create)', 'yellow');
+    o('  --description <desc>      Set PR description (used with pr create)', 'yellow');
     exit(0);
 }
 

--- a/src/Actions/Pr.php
+++ b/src/Actions/Pr.php
@@ -246,10 +246,15 @@ class Pr extends Base
             $fromBranch = trim(exec('git symbolic-ref --short HEAD'));
         }
 
+        $title = getUserInput('PR title (leave empty for default):');
+        $description = getUserInput('PR description (leave empty to skip):');
+
         $this->bulkCreate(
             explode(',', $toBranch),
             $fromBranch,
-            $addDefaultReviewers == 1
+            $addDefaultReviewers == 1,
+            $title ?: null,
+            $description ?: null
         );
     }
 
@@ -259,19 +264,21 @@ class Pr extends Base
      * @param array $toBranches
      * @param string $fromBranch
      * @param bool $addDefaultReviewers
+     * @param string|null $title
+     * @param string|null $description
      * @return void
      *
      * @throws \Exception
      */
-    private function bulkCreate($toBranches, $fromBranch, $addDefaultReviewers = true)
+    private function bulkCreate($toBranches, $fromBranch, $addDefaultReviewers = true, $title = null, $description = null)
     {
         $responses = [];
 
         $defaultReviewers = $addDefaultReviewers ? $this->defaultReviewers() : [];
 
         foreach ($toBranches as $toBranch) {
-            $response = $this->makeRequest('POST', '/pullrequests', [
-                'title' => "Merge {$fromBranch} into {$toBranch}",
+            $payload = [
+                'title' => $title ?? "Merge {$fromBranch} into {$toBranch}",
                 'source' => [
                     'branch' => [
                         'name' => $fromBranch,
@@ -283,7 +290,13 @@ class Pr extends Base
                     ],
                 ],
                 'reviewers' => $defaultReviewers,
-            ]);
+            ];
+
+            if ($description) {
+                $payload['description'] = $description;
+            }
+
+            $response = $this->makeRequest('POST', '/pullrequests', $payload);
 
             $responses[] = [
                 'id' => array_get($response, 'id'),

--- a/src/Actions/Pr.php
+++ b/src/Actions/Pr.php
@@ -246,15 +246,25 @@ class Pr extends Base
             $fromBranch = trim(exec('git symbolic-ref --short HEAD'));
         }
 
-        $title = getUserInput('PR title (leave empty for default):');
-        $description = getUserInput('PR description (leave empty to skip):');
+        $interactive = !empty($GLOBALS['bb_cli_interactive']);
+        $title = $GLOBALS['bb_cli_pr_title'] ?? null;
+        $description = $GLOBALS['bb_cli_pr_description'] ?? null;
+
+        if ($interactive) {
+            if (!$title) {
+                $title = getUserInput('PR title (leave empty for default):') ?: null;
+            }
+            if (!$description) {
+                $description = getUserInput('PR description (leave empty to skip):') ?: null;
+            }
+        }
 
         $this->bulkCreate(
             explode(',', $toBranch),
             $fromBranch,
             $addDefaultReviewers == 1,
-            $title ?: null,
-            $description ?: null
+            $title,
+            $description
         );
     }
 


### PR DESCRIPTION
Closes #29

- Prompt user for PR title and description when creating a PR
- If title is left empty, use the default 'Merge {source} into {destination}'
- If description is left empty, PR is created without a description
- Pass title and description through to bulkCreate and Bitbucket API